### PR TITLE
when the hotkeys are pressed, the type is shown for a second

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -851,3 +851,23 @@ button.ma_next_pack {
     display: inline-block;
     vertical-align: top;
 }
+
+.kbd-visual {
+    display: block;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    margin-top: -80px;
+    margin-left: -80px;
+    background: rgba(0, 0, 0, 0.6);
+    width: 120px;
+    height: 70px;
+    padding: 0px 20px;
+    border-radius: 10px;
+    color: white;
+    font-size: 30px;
+    text-align: center;
+    line-height: 70px;
+    font-family: monospace;
+    display: none;
+}

--- a/js/ner.js
+++ b/js/ner.js
@@ -59,6 +59,9 @@ var activateHotKeys = function() {
       btn = $(btn);
       Mousetrap.bind([btn.attr('data-hotkey') + ' ' + btn.attr('data-hotkey'),
                       'alt+' + btn.attr('data-hotkey')], function() {
+
+         $('body').append(d = $("<div>").addClass("kbd-visual").text(btn.text()));
+         d.fadeIn(100).delay(1000).fadeOut(100, function() { d.remove(); });
          btn.click();
       });
    });


### PR DESCRIPTION
Есть предложение по нажатию на хоткеи показывать на секунду, какой тип ты только что сохранил (чтобы глаза не перескакивали к таблице)

![2014-08-22 1 58 24](https://cloud.githubusercontent.com/assets/1223831/4004213/548ae09e-297e-11e4-87e0-a88062e1779e.png)
